### PR TITLE
Update README - use `makoctl` to reload the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 1. Clone this repository locally
 2. Copy the content of selected flavour file from `src` folder into `$HOME/.config/mako/config`
-3. Reload mako with `pkill mako`
+3. Reload mako with `makoctl reload`
 4. Enjoy
 
 ## 💝 Thanks to


### PR DESCRIPTION
I think it looks a bit clearer and cleaner if we use `makoctl reload` to reload the mako configuration after applying the catppuccin theme instead of killing the process. The command also works when mako is not currently running.

What do you think?